### PR TITLE
Fixed red LED

### DIFF
--- a/bsp/src/bsp_tm4c123_led.c
+++ b/bsp/src/bsp_tm4c123_led.c
@@ -18,7 +18,7 @@ void bsp_red_led(led_value_t value)
   }
   else
   {
-    GPIOF->DATA &= ~BIT1;
+    GPIOF->DATA &= ~BIT0;
   }
 }
 


### PR DESCRIPTION
Fixed bsp_red_led function call, because it was using BIT1 instead of BIT0.